### PR TITLE
Cover improv and misc fixes

### DIFF
--- a/binding_cache_test.go
+++ b/binding_cache_test.go
@@ -1,0 +1,200 @@
+package pave
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Test BindingCache functionality
+func TestBindingCache(t *testing.T) {
+	t.Run("NewBindingCache", func(t *testing.T) {
+		cache := NewBindingCache[string, int]()
+		assert.NotNil(t, cache)
+	})
+
+	t.Run("GetOrCreate", func(t *testing.T) {
+		cache := NewBindingCache[string, int]()
+		source := "test"
+		sourcePtr := &source // Use the same pointer throughout the test
+
+		// First call should create
+		entry1 := cache.GetOrCreate(sourcePtr, func() int { return 42 })
+		assert.NotNil(t, entry1)
+		assert.Equal(t, 42, entry1.GetData())
+
+		// Second call should return same entry (same pointer, same key)
+		entry2 := cache.GetOrCreate(sourcePtr, func() int {
+			t.Error("Factory function should not be called second time")
+			return 99
+		})
+
+		// Check that we got the same entry back
+		if entry1 != entry2 {
+			t.Errorf("Expected same entry, got different ones. Entry1: %p (data: %d), Entry2: %p (data: %d)",
+				entry1, entry1.GetData(), entry2, entry2.GetData())
+		}
+
+		// Check that the data is from the first call
+		assert.Equal(t, 42, entry2.GetData(), "Second call should return entry with data from first call")
+	})
+
+	t.Run("Get", func(t *testing.T) {
+		cache := NewBindingCache[string, int]()
+		source := "test"
+		sourcePtr := &source
+
+		// Should not exist initially
+		entry, exists := cache.Get(sourcePtr)
+		assert.Nil(t, entry)
+		assert.False(t, exists)
+
+		// Create entry
+		created := cache.GetOrCreate(sourcePtr, func() int { return 42 })
+
+		// Should exist now
+		entry, exists = cache.Get(sourcePtr)
+		assert.NotNil(t, entry)
+		assert.True(t, exists)
+		assert.Equal(t, created, entry)
+	})
+
+	t.Run("Delete", func(t *testing.T) {
+		cache := NewBindingCache[string, int]()
+		source := "test"
+		sourcePtr := &source
+
+		// Create entry
+		cache.GetOrCreate(sourcePtr, func() int { return 42 })
+
+		// Verify it exists
+		entry, exists := cache.Get(sourcePtr)
+		assert.True(t, exists)
+		assert.NotNil(t, entry)
+
+		// Delete it
+		cache.Delete(sourcePtr)
+
+		// Should not exist now
+		entry, exists = cache.Get(sourcePtr)
+		assert.False(t, exists)
+		assert.Nil(t, entry)
+	})
+
+	t.Run("Clear", func(t *testing.T) {
+		cache := NewBindingCache[string, int]()
+		source1 := "test1"
+		source2 := "test2"
+		sourcePtr1 := &source1
+		sourcePtr2 := &source2
+
+		// Create multiple entries
+		cache.GetOrCreate(sourcePtr1, func() int { return 42 })
+		cache.GetOrCreate(sourcePtr2, func() int { return 99 })
+
+		// Verify they exist
+		entry1, exists1 := cache.Get(sourcePtr1)
+		entry2, exists2 := cache.Get(sourcePtr2)
+		assert.True(t, exists1)
+		assert.True(t, exists2)
+		assert.NotNil(t, entry1)
+		assert.NotNil(t, entry2)
+
+		// Clear all
+		cache.Clear()
+
+		// Should not exist now
+		entry1, exists1 = cache.Get(sourcePtr1)
+		entry2, exists2 = cache.Get(sourcePtr2)
+		assert.False(t, exists1)
+		assert.False(t, exists2)
+		assert.Nil(t, entry1)
+		assert.Nil(t, entry2)
+	})
+}
+
+// Test CacheEntry functionality
+func TestCacheEntry(t *testing.T) {
+	t.Run("ReadData", func(t *testing.T) {
+		cache := NewBindingCache[string, int]()
+		source := "test"
+		sourcePtr := &source
+
+		entry := cache.GetOrCreate(sourcePtr, func() int { return 42 })
+
+		var readValue int
+		entry.ReadData(func(data int) {
+			readValue = data
+		})
+
+		assert.Equal(t, 42, readValue)
+	})
+
+	t.Run("WriteData", func(t *testing.T) {
+		cache := NewBindingCache[string, int]()
+		source := "test"
+		sourcePtr := &source
+
+		entry := cache.GetOrCreate(sourcePtr, func() int { return 42 })
+
+		// Write new value
+		entry.WriteData(func(data *int) {
+			*data = 99
+		})
+
+		// Verify it was written
+		assert.Equal(t, 99, entry.GetData())
+	})
+
+	t.Run("GetData", func(t *testing.T) {
+		cache := NewBindingCache[string, int]()
+		source := "test"
+		sourcePtr := &source
+
+		entry := cache.GetOrCreate(sourcePtr, func() int { return 42 })
+
+		data := entry.GetData()
+		assert.Equal(t, 42, data)
+	})
+
+	t.Run("ConcurrentAccess", func(t *testing.T) {
+		cache := NewBindingCache[string, int]()
+		source := "test"
+		sourcePtr := &source
+
+		entry := cache.GetOrCreate(sourcePtr, func() int { return 0 })
+
+		// Test concurrent read/write access
+		done := make(chan bool, 2)
+
+		// Writer goroutine
+		go func() {
+			for i := 0; i < 100; i++ {
+				entry.WriteData(func(data *int) {
+					*data = i
+				})
+			}
+			done <- true
+		}()
+
+		// Reader goroutine
+		go func() {
+			for i := 0; i < 100; i++ {
+				entry.ReadData(func(data int) {
+					// Just read the data, don't need to verify specific value
+					// due to concurrent access
+					_ = data
+				})
+			}
+			done <- true
+		}()
+
+		// Wait for both goroutines
+		<-done
+		<-done
+
+		// Test should not panic or race
+		finalValue := entry.GetData()
+		assert.True(t, finalValue >= 0 && finalValue < 100)
+	})
+}

--- a/binding_test.go
+++ b/binding_test.go
@@ -1,0 +1,37 @@
+package pave
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Test BindingResult functions
+func TestBindingResult(t *testing.T) {
+	t.Run("BindingResultError", func(t *testing.T) {
+		testErr := errors.New("test error")
+		result := BindingResultError(testErr)
+
+		assert.Nil(t, result.Value)
+		assert.False(t, result.Found)
+		assert.Equal(t, testErr, result.Error)
+	})
+
+	t.Run("BindingResultNotFound", func(t *testing.T) {
+		result := BindingResultNotFound()
+
+		assert.Nil(t, result.Value)
+		assert.False(t, result.Found)
+		assert.Nil(t, result.Error)
+	})
+
+	t.Run("BindingResultValue", func(t *testing.T) {
+		testValue := "test value"
+		result := BindingResultValue(testValue)
+
+		assert.Equal(t, testValue, result.Value)
+		assert.True(t, result.Found)
+		assert.Nil(t, result.Error)
+	})
+}

--- a/doc.go
+++ b/doc.go
@@ -27,9 +27,9 @@
 // validate the struct's fields after they have been populated by the parsers.
 //
 // Custom parser come in two flavors:
-//   - OneShotSourceParser: Parses from a single source type, such as a byte slice
-//     or a string. It is used when the source is expected to be a single value.
-//     These parsers do not support multiple sources for a single field.
+//   - OneShotSourceParser: Parses from a source type with a single binding,
+//     such as a byte slice or a string. It is used when the source is expected
+//     to be a single value.
 //   - MultipleSourceParser: Parses from sources with multiple interaction methods,
 //     such as a HTTP request. These parsers build a ParseExecutionChain (see
 //     [parseChainBuilder](https://pkg.go.dev/pave#ChainExecutor) and
@@ -41,16 +41,6 @@
 //
 // All parsers must implement the [Parser](https://pkg.go.dev/pave#SourceParser) interface,
 // which defines the methods required for parsing data from a source into a Validatable type.
-//
-// All parsers must also support the following source tag modifiers:
-//   - `omitempty`: If the field is empty, it will not be parsed. If a fallback source
-//     is specified, an attempt to use it instead will be made.
-//   - `required`: The field must be present in the source, otherwise an
-//     error will be returned. The first instance of `required` as a tag modifier
-//     will cut the generation of the parse execution chain. That is, all `omitempty`
-//     tags after the first `required` will be ignored, and the field will be required
-//     to be present in the source. `required` is IMPLIED by default. At most one `required`
-//     modifier can be present per field.
 package pave
 
 /**
@@ -62,12 +52,12 @@ PLANNING:
     2. Must be able to validate for Validatable or for types that can possibly be converted to Validatable by boxing them
     3. Build Tags for enabling integrations/featureflags
 - Formalize tag grammar, create generic tag parser for MultiStepSourceParser and OneShotSourceParser (DONE)
-    - Tag grammar shown below.
+    - Tag grammar shown [tag.go](tag.go)
 - Tag aliasing.
 - Global Tag String White/Blacklist registry
     - Allow per tag parse includes/excludes but also global excludes that can be set. (WIP)
 - Split Package into PAVE-Parser and PAVE-Validator
 - Implement Validation
-- Add support for custom parsers that can be registered with the Validator. (DONE)
-- Add support for custom validators that can be registered with the Validator.
+- Add support for custom parsers that can be registered with the Registry. (DONE)
+- Add support for custom validators that can be registered with the Registry.
 */

--- a/helpers.go
+++ b/helpers.go
@@ -1,9 +1,11 @@
 package pave
 
 import (
+	"encoding"
 	"fmt"
 	"reflect"
 	"strconv"
+	"time"
 
 	"github.com/google/uuid"
 )
@@ -16,72 +18,248 @@ import (
 //
 // Currently supports:
 //   - string to string
-//   - string to int
+//   - string to int (with overflow checking)
 //   - string to bool
-//   - string to float64
+//   - string to float64 (with overflow checking)
 //   - string to uuid.UUID
 //   - string to []byte (raw byte slice)
 //   - string to array of uuid.UUID
 //   - string to struct with uuid.UUID field
 //   - string to struct with time.Time field
+//   - TextUnmarshaler support for custom types
+//   - Interface{} support for any type
 func setFieldValue(field reflect.Value, value string) error {
-	switch field.Kind() {
-	// If the field is a string, set it directly
-	case reflect.String:
-		field.SetString(value)
-	// If the field is a array, check if it is an
-	case reflect.Array:
-		if field.Type() == UUIDType {
-			uuidValue, err := uuid.Parse(value)
-			if err != nil {
-				return fmt.Errorf("error converting query value to UUID: %w", err)
-			}
-			field.Set(reflect.ValueOf(uuidValue))
-		}
-	// If the field is an int, convert the query value to int
-	case reflect.Int:
-		intValue, err := strconv.Atoi(value)
-		if err != nil {
-			return fmt.Errorf("error converting query value to int: %w", err)
-		}
-		field.SetInt(int64(intValue))
-	case reflect.Bool:
-		// If the field is a bool, convert the query value to bool
-		boolValue, err := strconv.ParseBool(value)
-		if err != nil {
-			return fmt.Errorf("error converting query value to bool: %w", err)
-		}
-		field.SetBool(boolValue)
-	case reflect.Float64:
-		// If the field is a float64, convert the query value to float64
-		floatValue, err := strconv.ParseFloat(value, 64)
-		if err != nil {
-			return fmt.Errorf("error converting query value to float64: %w", err)
-		}
-		field.SetFloat(floatValue)
-	case reflect.Slice:
-		// If the field is a byte slice, detect if value is base64 or raw string
-		if field.Type().Elem().Kind() == reflect.Uint8 {
-			data := []byte(value)
-			field.SetBytes(data)
-		} else {
-			return fmt.Errorf("unsupported slice type for query: %s", field.Type().Name())
-		}
-	case reflect.Struct:
-		// Handle uuid.UUID type
-		if field.Type() == reflect.TypeOf(uuid.UUID{}) {
-			uuidValue, err := uuid.Parse(value)
-			if err != nil {
-				return fmt.Errorf("error converting query value to UUID: %w", err)
-			}
-			field.Set(reflect.ValueOf(uuidValue))
-		} else {
-			return fmt.Errorf("unsupported struct type for query: %s", field.Type().Name())
-		}
-	default:
-		return fmt.Errorf("unsupported field type for query: %s", field.Type().Name())
+	// Handle nil/empty values
+	if value == "" {
+		return handleEmptyValue(field)
 	}
 
+	// Check for TextUnmarshaler interface
+	if field.CanInterface() {
+		if unmarshaler, ok := field.Interface().(encoding.TextUnmarshaler); ok {
+			return unmarshaler.UnmarshalText([]byte(value))
+		}
+		// Check for pointer to TextUnmarshaler
+		if field.CanAddr() {
+			if unmarshaler, ok := field.Addr().Interface().(encoding.TextUnmarshaler); ok {
+				return unmarshaler.UnmarshalText([]byte(value))
+			}
+		}
+	}
+
+	switch field.Kind() {
+	case reflect.String:
+		return setStringValue(field, value)
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return setIntValue(field, value)
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return setUintValue(field, value)
+	case reflect.Float32, reflect.Float64:
+		return setFloatValue(field, value)
+	case reflect.Complex64, reflect.Complex128:
+		return setComplexValue(field, value)
+	case reflect.Bool:
+		return setBoolValue(field, value)
+	case reflect.Slice:
+		return setSliceValue(field, value)
+	case reflect.Array:
+		return setArrayValue(field, value)
+	case reflect.Struct:
+		return setStructValue(field, value)
+	case reflect.Interface:
+		return setInterfaceValue(field, value)
+	default:
+		return fmt.Errorf("unsupported field type: %s", field.Type().Name())
+	}
+}
+
+// handleEmptyValue handles empty string values for different field types
+func handleEmptyValue(field reflect.Value) error {
+	switch field.Kind() {
+	case reflect.String:
+		field.SetString("")
+		return nil
+	case reflect.Slice, reflect.Map, reflect.Ptr, reflect.Interface:
+		field.SetZero()
+		return nil
+	default:
+		return fmt.Errorf("cannot set empty value for field type: %s", field.Type().Name())
+	}
+}
+
+// setStringValue sets string field values
+func setStringValue(field reflect.Value, value string) error {
+	field.SetString(value)
+	return nil
+}
+
+// setIntValue sets integer field values with overflow checking
+func setIntValue(field reflect.Value, value string) error {
+	intValue, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		return fmt.Errorf("error converting value to int: %w", err)
+	}
+
+	if field.OverflowInt(intValue) {
+		return fmt.Errorf("value %d overflows %s", intValue, field.Type().Name())
+	}
+
+	field.SetInt(intValue)
+	return nil
+}
+
+// setUintValue sets unsigned integer field values with overflow checking
+func setUintValue(field reflect.Value, value string) error {
+	uintValue, err := strconv.ParseUint(value, 10, 64)
+	if err != nil {
+		return fmt.Errorf("error converting value to uint: %w", err)
+	}
+
+	if field.OverflowUint(uintValue) {
+		return fmt.Errorf("value %d overflows %s", uintValue, field.Type().Name())
+	}
+
+	field.SetUint(uintValue)
+	return nil
+}
+
+// setFloatValue sets float field values with overflow checking
+func setFloatValue(field reflect.Value, value string) error {
+	floatValue, err := strconv.ParseFloat(value, field.Type().Bits())
+	if err != nil {
+		return fmt.Errorf("error converting value to float: %w", err)
+	}
+
+	if field.OverflowFloat(floatValue) {
+		return fmt.Errorf("value %f overflows %s", floatValue, field.Type().Name())
+	}
+
+	field.SetFloat(floatValue)
+	return nil
+}
+
+// setComplexValue sets complex field values
+func setComplexValue(field reflect.Value, value string) error {
+	complexValue, err := strconv.ParseComplex(value, field.Type().Bits())
+	if err != nil {
+		return fmt.Errorf("error converting value to complex: %w", err)
+	}
+
+	if field.OverflowComplex(complexValue) {
+		return fmt.Errorf("value %v overflows %s", complexValue, field.Type().Name())
+	}
+
+	field.SetComplex(complexValue)
+	return nil
+}
+
+// setBoolValue sets boolean field values with better validation
+//
+// Many common boolean representations are supported:
+//   - "true", "1", "yes", "on" (case insensitive)
+//   - "false", "0", "no", "off" (case insensitive)
+//   - Standard boolean parsing using strconv.ParseBool
+func setBoolValue(field reflect.Value, value string) error {
+	// Handle common boolean representations
+	switch value {
+	case "true", "1", "yes", "on", "True", "TRUE", "YES", "ON":
+		field.SetBool(true)
+		return nil
+	case "false", "0", "no", "off", "False", "FALSE", "NO", "OFF":
+		field.SetBool(false)
+		return nil
+	default:
+		// Fall back to standard parsing
+		boolValue, err := strconv.ParseBool(value)
+		if err != nil {
+			return fmt.Errorf("error converting value to bool: %w", err)
+		}
+		field.SetBool(boolValue)
+		return nil
+	}
+}
+
+// setSliceValue sets slice field values
+func setSliceValue(field reflect.Value, value string) error {
+	elemType := field.Type().Elem()
+
+	switch elemType.Kind() {
+	case reflect.Uint8:
+		// []byte slice
+		field.SetBytes([]byte(value))
+		return nil
+	default:
+		return fmt.Errorf("unsupported slice type: %s", field.Type().Name())
+	}
+}
+
+// setArrayValue sets array field values
+func setArrayValue(field reflect.Value, value string) error {
+	if field.Type() == UUIDType {
+		uuidValue, err := uuid.Parse(value)
+		if err != nil {
+			return fmt.Errorf("error converting value to UUID: %w", err)
+		}
+		field.Set(reflect.ValueOf(uuidValue))
+		return nil
+	}
+
+	return fmt.Errorf("unsupported array type: %s", field.Type().Name())
+}
+
+// setStructValue sets struct field values for special types
+func setStructValue(field reflect.Value, value string) error {
+	fieldType := field.Type()
+
+	// Handle UUID type
+	if fieldType == UUIDType {
+		uuidValue, err := uuid.Parse(value)
+		if err != nil {
+			return fmt.Errorf("error converting value to UUID: %w", err)
+		}
+		field.Set(reflect.ValueOf(uuidValue))
+		return nil
+	}
+
+	// Handle time.Time type
+	if fieldType == TimeType {
+		timeValue, err := time.Parse(time.RFC3339, value)
+		if err != nil {
+			// Try common time formats
+			formats := []string{
+				time.RFC3339,
+				time.RFC3339Nano,
+				"2006-01-02T15:04:05",
+				"2006-01-02 15:04:05",
+				"2006-01-02",
+				"15:04:05",
+			}
+
+			for _, format := range formats {
+				if timeValue, err = time.Parse(format, value); err == nil {
+					break
+				}
+			}
+
+			if err != nil {
+				return fmt.Errorf("error converting value to time.Time: %w", err)
+			}
+		}
+		field.Set(reflect.ValueOf(timeValue))
+		return nil
+	}
+
+	return fmt.Errorf("unsupported struct type: %s", fieldType.Name())
+}
+
+// setInterfaceValue sets interface{} field values
+func setInterfaceValue(field reflect.Value, value string) error {
+	if field.NumMethod() != 0 {
+		return fmt.Errorf("cannot set value for interface with methods: %s", field.Type().Name())
+	}
+
+	// For empty interface, store as string
+	field.Set(reflect.ValueOf(value))
 	return nil
 }
 

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -1,0 +1,841 @@
+package pave
+
+import (
+	"encoding"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Custom type that implements TextUnmarshaler
+type CustomTextType struct {
+	Value string
+}
+
+func (c *CustomTextType) UnmarshalText(text []byte) error {
+	if string(text) == "error" {
+		return errors.New("custom error")
+	}
+	c.Value = "custom:" + string(text)
+	return nil
+}
+
+// Custom type that implements TextUnmarshaler on pointer
+type CustomPointerType struct {
+	Value string
+}
+
+func (c *CustomPointerType) UnmarshalText(text []byte) error {
+	if string(text) == "error" {
+		return errors.New("custom pointer error")
+	}
+	c.Value = "pointer:" + string(text)
+	return nil
+}
+
+// Helper function to create a reflect.Value from any type
+func valueFromInterface(v interface{}) reflect.Value {
+	return reflect.ValueOf(v).Elem()
+}
+
+// Test for setFieldValue main function
+func TestSetFieldValue(t *testing.T) {
+	tests := []struct {
+		name    string
+		field   interface{}
+		value   string
+		want    interface{}
+		wantErr bool
+	}{
+		// String tests
+		{"string_basic", ptr(""), "hello", "hello", false},
+		{"string_empty", ptr(""), "", "", false},
+
+		// Integer tests
+		{"int_basic", ptr(int(0)), "42", int(42), false},
+		{"int8_basic", ptr(int8(0)), "127", int8(127), false},
+		{"int16_basic", ptr(int16(0)), "32767", int16(32767), false},
+		{"int32_basic", ptr(int32(0)), "2147483647", int32(2147483647), false},
+		{"int64_basic", ptr(int64(0)), "9223372036854775807", int64(9223372036854775807), false},
+		{"int_overflow", ptr(int8(0)), "128", int8(0), true},
+		{"int_invalid", ptr(int(0)), "abc", int(0), true},
+
+		// Unsigned integer tests
+		{"uint_basic", ptr(uint(0)), "42", uint(42), false},
+		{"uint8_basic", ptr(uint8(0)), "255", uint8(255), false},
+		{"uint16_basic", ptr(uint16(0)), "65535", uint16(65535), false},
+		{"uint32_basic", ptr(uint32(0)), "4294967295", uint32(4294967295), false},
+		{"uint64_basic", ptr(uint64(0)), "18446744073709551615", uint64(18446744073709551615), false},
+		{"uint_overflow", ptr(uint8(0)), "256", uint8(0), true},
+		{"uint_invalid", ptr(uint(0)), "abc", uint(0), true},
+
+		// Float tests
+		{"float32_basic", ptr(float32(0)), "3.14", float32(3.14), false},
+		{"float64_basic", ptr(float64(0)), "3.14159265359", float64(3.14159265359), false},
+		{"float_overflow", ptr(float32(0)), "3.4028235e+39", float32(0), true},
+		{"float_invalid", ptr(float64(0)), "abc", float64(0), true},
+
+		// Complex tests
+		{"complex64_basic", ptr(complex64(0)), "1+2i", complex64(1 + 2i), false},
+		{"complex128_basic", ptr(complex128(0)), "1.5+2.5i", complex128(1.5 + 2.5i), false},
+		{"complex_invalid", ptr(complex64(0)), "abc", complex64(0), true},
+
+		// Boolean tests
+		{"bool_true", ptr(false), "true", true, false},
+		{"bool_false", ptr(true), "false", false, false},
+		{"bool_yes", ptr(false), "yes", true, false},
+		{"bool_no", ptr(true), "no", false, false},
+		{"bool_on", ptr(false), "on", true, false},
+		{"bool_off", ptr(true), "off", false, false},
+		{"bool_1", ptr(false), "1", true, false},
+		{"bool_0", ptr(true), "0", false, false},
+		{"bool_case_insensitive", ptr(false), "TRUE", true, false},
+		{"bool_invalid", ptr(false), "maybe", false, true},
+
+		// Slice tests
+		{"slice_bytes", ptr([]byte{}), "hello", []byte("hello"), false},
+
+		// UUID tests (struct)
+		{"uuid_valid", ptr(uuid.UUID{}), "550e8400-e29b-41d4-a716-446655440000", uuid.MustParse("550e8400-e29b-41d4-a716-446655440000"), false},
+		{"uuid_invalid", ptr(uuid.UUID{}), "invalid-uuid", uuid.UUID{}, true},
+
+		// Time tests
+		{"time_rfc3339", ptr(time.Time{}), "2023-01-01T00:00:00Z", time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC), false},
+		{"time_invalid_rfc3339", ptr(time.Time{}), "2023-01-01", time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC), true},
+		{"time_invalid", ptr(time.Time{}), "invalid-time", time.Time{}, true},
+
+		// Interface tests
+		{"interface_empty", ptr(interface{}(nil)), "hello", "hello", false},
+
+		// TextUnmarshaler tests
+		{"custom_text_unmarshaler", ptr(CustomTextType{}), "test", CustomTextType{Value: "custom:test"}, false},
+		{"custom_text_error", ptr(CustomTextType{}), "error", CustomTextType{}, true},
+		{"custom_pointer_unmarshaler", ptr(CustomPointerType{}), "test", CustomPointerType{Value: "pointer:test"}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			field := valueFromInterface(tt.field)
+			err := setFieldValue(field, tt.value)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("setFieldValue() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !tt.wantErr {
+				got := field.Interface()
+				if !reflect.DeepEqual(got, tt.want) {
+					t.Errorf("setFieldValue() got = %v, want %v", got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+// Test for handleEmptyValue function
+func TestHandleEmptyValue(t *testing.T) {
+	tests := []struct {
+		name    string
+		field   interface{}
+		want    interface{}
+		wantErr bool
+	}{
+		{"string_empty", ptr("test"), "", false},
+		{"slice_empty", ptr([]byte{1, 2, 3}), []byte(nil), false},
+		{"map_empty", ptr(map[string]int{"a": 1}), map[string]int(nil), false},
+		{"ptr_empty", ptr(&struct{}{}), (*struct{})(nil), false},
+		{"interface_empty", ptr(interface{}("test")), interface{}(nil), false},
+		{"int_empty", ptr(int(42)), int(0), true}, // Should error
+		{"bool_empty", ptr(true), false, true},    // Should error
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			field := valueFromInterface(tt.field)
+			err := handleEmptyValue(field)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("handleEmptyValue() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !tt.wantErr {
+				got := field.Interface()
+				if !reflect.DeepEqual(got, tt.want) {
+					t.Errorf("handleEmptyValue() got = %v, want %v", got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+// Test for individual setter functions
+func TestSetStringValue(t *testing.T) {
+	var s string
+	field := reflect.ValueOf(&s).Elem()
+
+	err := setStringValue(field, "hello")
+	if err != nil {
+		t.Errorf("setStringValue() error = %v", err)
+	}
+	if s != "hello" {
+		t.Errorf("setStringValue() got = %v, want %v", s, "hello")
+	}
+}
+
+func TestSetIntValue(t *testing.T) {
+	tests := []struct {
+		name    string
+		field   interface{}
+		value   string
+		want    interface{}
+		wantErr bool
+	}{
+		{"int_valid", ptr(int(0)), "42", int(42), false},
+		{"int8_valid", ptr(int8(0)), "127", int8(127), false},
+		{"int8_overflow", ptr(int8(0)), "128", int8(0), true},
+		{"int_invalid", ptr(int(0)), "abc", int(0), true},
+		{"int_negative", ptr(int(0)), "-42", int(-42), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			field := valueFromInterface(tt.field)
+			err := setIntValue(field, tt.value)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("setIntValue() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !tt.wantErr {
+				got := field.Interface()
+				if !reflect.DeepEqual(got, tt.want) {
+					t.Errorf("setIntValue() got = %v, want %v", got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+func TestSetUintValue(t *testing.T) {
+	tests := []struct {
+		name    string
+		field   interface{}
+		value   string
+		want    interface{}
+		wantErr bool
+	}{
+		{"uint_valid", ptr(uint(0)), "42", uint(42), false},
+		{"uint8_valid", ptr(uint8(0)), "255", uint8(255), false},
+		{"uint8_overflow", ptr(uint8(0)), "256", uint8(0), true},
+		{"uint_invalid", ptr(uint(0)), "abc", uint(0), true},
+		{"uint_negative", ptr(uint(0)), "-1", uint(0), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			field := valueFromInterface(tt.field)
+			err := setUintValue(field, tt.value)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("setUintValue() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !tt.wantErr {
+				got := field.Interface()
+				if !reflect.DeepEqual(got, tt.want) {
+					t.Errorf("setUintValue() got = %v, want %v", got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+func TestSetFloatValue(t *testing.T) {
+	tests := []struct {
+		name    string
+		field   interface{}
+		value   string
+		want    interface{}
+		wantErr bool
+	}{
+		{"float32_valid", ptr(float32(0)), "3.14", float32(3.14), false},
+		{"float64_valid", ptr(float64(0)), "3.14159265359", float64(3.14159265359), false},
+		{"float32_overflow", ptr(float32(0)), "3.4028235e+39", float32(0), true},
+		{"float_invalid", ptr(float64(0)), "abc", float64(0), true},
+		{"float_negative", ptr(float64(0)), "-3.14", float64(-3.14), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			field := valueFromInterface(tt.field)
+			err := setFloatValue(field, tt.value)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("setFloatValue() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !tt.wantErr {
+				got := field.Interface()
+				if !reflect.DeepEqual(got, tt.want) {
+					t.Errorf("setFloatValue() got = %v, want %v", got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+func TestSetComplexValue(t *testing.T) {
+	tests := []struct {
+		name    string
+		field   interface{}
+		value   string
+		want    interface{}
+		wantErr bool
+	}{
+		{"complex64_valid", ptr(complex64(0)), "1+2i", complex64(1 + 2i), false},
+		{"complex128_valid", ptr(complex128(0)), "1.5+2.5i", complex128(1.5 + 2.5i), false},
+		{"complex_real_only", ptr(complex64(0)), "42", complex64(42), false},
+		{"complex_invalid", ptr(complex64(0)), "abc", complex64(0), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			field := valueFromInterface(tt.field)
+			err := setComplexValue(field, tt.value)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("setComplexValue() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !tt.wantErr {
+				got := field.Interface()
+				if !reflect.DeepEqual(got, tt.want) {
+					t.Errorf("setComplexValue() got = %v, want %v", got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+func TestSetBoolValue(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		want    bool
+		wantErr bool
+	}{
+		// True values
+		{"true_lowercase", "true", true, false},
+		{"true_uppercase", "TRUE", true, false},
+		{"true_mixed", "True", true, false},
+		{"one", "1", true, false},
+		{"yes_lowercase", "yes", true, false},
+		{"yes_uppercase", "YES", true, false},
+		{"on_lowercase", "on", true, false},
+		{"on_uppercase", "ON", true, false},
+
+		// False values
+		{"false_lowercase", "false", false, false},
+		{"false_uppercase", "FALSE", false, false},
+		{"false_mixed", "False", false, false},
+		{"zero", "0", false, false},
+		{"no_lowercase", "no", false, false},
+		{"no_uppercase", "NO", false, false},
+		{"off_lowercase", "off", false, false},
+		{"off_uppercase", "OFF", false, false},
+
+		// strconv.ParseBool fallback
+		{"t", "t", true, false},
+		{"f", "f", false, false},
+
+		// Invalid values
+		{"invalid", "maybe", false, true},
+		{"empty", "", false, true},
+		{"random", "random", false, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var b bool
+			field := reflect.ValueOf(&b).Elem()
+			err := setBoolValue(field, tt.value)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("setBoolValue() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !tt.wantErr && b != tt.want {
+				t.Errorf("setBoolValue() got = %v, want %v", b, tt.want)
+			}
+		})
+	}
+}
+
+func TestSetSliceValue(t *testing.T) {
+	tests := []struct {
+		name    string
+		field   interface{}
+		value   string
+		want    interface{}
+		wantErr bool
+	}{
+		{"byte_slice", ptr([]byte{}), "hello", []byte("hello"), false},
+		{"string_slice", ptr([]string{}), "hello", []string{}, true}, // Should error
+		{"int_slice", ptr([]int{}), "hello", []int{}, true},          // Should error
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			field := valueFromInterface(tt.field)
+			err := setSliceValue(field, tt.value)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("setSliceValue() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !tt.wantErr {
+				got := field.Interface()
+				if !reflect.DeepEqual(got, tt.want) {
+					t.Errorf("setSliceValue() got = %v, want %v", got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+func TestSetArrayValue(t *testing.T) {
+	tests := []struct {
+		name    string
+		field   interface{}
+		value   string
+		want    interface{}
+		wantErr bool
+	}{
+		{"uuid_valid", ptr(uuid.UUID{}), "550e8400-e29b-41d4-a716-446655440000", uuid.MustParse("550e8400-e29b-41d4-a716-446655440000"), false},
+		{"uuid_invalid", ptr(uuid.UUID{}), "invalid-uuid", uuid.UUID{}, true},
+		{"int_array", ptr([3]int{}), "123", [3]int{}, true}, // Should error
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			field := valueFromInterface(tt.field)
+			err := setArrayValue(field, tt.value)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("setArrayValue() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !tt.wantErr {
+				got := field.Interface()
+				if !reflect.DeepEqual(got, tt.want) {
+					t.Errorf("setArrayValue() got = %v, want %v", got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+func TestSetStructValue(t *testing.T) {
+	tests := []struct {
+		name    string
+		field   interface{}
+		value   string
+		want    interface{}
+		wantErr bool
+	}{
+		// UUID tests
+		{"uuid_valid", ptr(uuid.UUID{}), "550e8400-e29b-41d4-a716-446655440000", uuid.MustParse("550e8400-e29b-41d4-a716-446655440000"), false},
+		{"uuid_invalid", ptr(uuid.UUID{}), "invalid-uuid", uuid.UUID{}, true},
+
+		// Time tests
+		{"time_rfc3339", ptr(time.Time{}), "2023-01-01T00:00:00Z", time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC), false},
+		{"time_rfc3339_nano", ptr(time.Time{}), "2023-01-01T00:00:00.123456789Z", time.Date(2023, 1, 1, 0, 0, 0, 123456789, time.UTC), false},
+		{"time_no_timezone", ptr(time.Time{}), "2023-01-01T00:00:00", time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC), false},
+		{"time_with_space", ptr(time.Time{}), "2023-01-01 00:00:00", time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC), false},
+		{"time_date_only", ptr(time.Time{}), "2023-01-01", time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC), false},
+		{"time_time_only", ptr(time.Time{}), "15:04:05", time.Date(0, 1, 1, 15, 4, 5, 0, time.UTC), false},
+		{"time_invalid", ptr(time.Time{}), "invalid-time", time.Time{}, true},
+
+		// Unsupported struct
+		{"custom_struct", ptr(struct{ Name string }{}), "test", struct{ Name string }{}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			field := valueFromInterface(tt.field)
+			err := setStructValue(field, tt.value)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("setStructValue() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !tt.wantErr {
+				got := field.Interface()
+				if !reflect.DeepEqual(got, tt.want) {
+					t.Errorf("setStructValue() got = %v, want %v", got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+func TestSetInterfaceValue(t *testing.T) {
+	tests := []struct {
+		name    string
+		field   interface{}
+		value   string
+		want    interface{}
+		wantErr bool
+	}{
+		{"empty_interface", ptr(interface{}(nil)), "hello", "hello", false},
+		{"interface_with_methods", ptr(encoding.TextUnmarshaler(nil)), "hello", nil, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			field := valueFromInterface(tt.field)
+			err := setInterfaceValue(field, tt.value)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("setInterfaceValue() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !tt.wantErr {
+				got := field.Interface()
+				if !reflect.DeepEqual(got, tt.want) {
+					t.Errorf("setInterfaceValue() got = %v, want %v", got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+// Test for zeroStructFields function
+func TestZeroStructFields(t *testing.T) {
+	type NestedStruct struct {
+		NestedField int
+	}
+
+	type TestStruct struct {
+		StringField string
+		IntField    int
+		BoolField   bool
+		FloatField  float64
+		SliceField  []int
+		MapField    map[string]int
+		PtrField    *int
+		UUIDField   uuid.UUID
+		TimeField   time.Time
+		NestedField NestedStruct
+		unexported  int // Should be skipped
+	}
+
+	// Create a struct with non-zero values
+	original := TestStruct{
+		StringField: "hello",
+		IntField:    42,
+		BoolField:   true,
+		FloatField:  3.14,
+		SliceField:  []int{1, 2, 3},
+		MapField:    map[string]int{"key": 1},
+		PtrField:    &[]int{123}[0],
+		UUIDField:   uuid.MustParse("550e8400-e29b-41d4-a716-446655440000"),
+		TimeField:   time.Now(),
+		NestedField: NestedStruct{NestedField: 99},
+		unexported:  999,
+	}
+
+	// Zero the struct
+	value := reflect.ValueOf(&original).Elem()
+	zeroStructFields(value)
+
+	// Check that all fields are zeroed
+	expected := TestStruct{
+		unexported: 999, // Should remain unchanged
+	}
+
+	if !reflect.DeepEqual(original, expected) {
+		t.Errorf("zeroStructFields() failed to zero all fields correctly")
+		t.Errorf("Got: %+v", original)
+		t.Errorf("Expected: %+v", expected)
+	}
+}
+
+func TestZeroStructFields_NonStruct(t *testing.T) {
+	// Test with non-struct value
+	var i int = 42
+	value := reflect.ValueOf(&i).Elem()
+	zeroStructFields(value) // Should not panic and should not change value
+
+	if i != 42 {
+		t.Errorf("zeroStructFields() should not affect non-struct values, got %d", i)
+	}
+}
+
+func TestZeroStructFields_UnexportedFields(t *testing.T) {
+	type TestStruct struct {
+		ExportedField   int
+		unexportedField int
+	}
+
+	original := TestStruct{
+		ExportedField:   42,
+		unexportedField: 99,
+	}
+
+	value := reflect.ValueOf(&original).Elem()
+	zeroStructFields(value)
+
+	// Exported field should be zeroed, unexported should remain
+	if original.ExportedField != 0 {
+		t.Errorf("zeroStructFields() should zero exported field, got %d", original.ExportedField)
+	}
+	if original.unexportedField != 99 {
+		t.Errorf("zeroStructFields() should not affect unexported field, got %d", original.unexportedField)
+	}
+}
+
+// Test for isSpecialStructType function
+func TestIsSpecialStructType(t *testing.T) {
+	tests := []struct {
+		name string
+		t    reflect.Type
+		want bool
+	}{
+		{"time.Time", reflect.TypeOf(time.Time{}), true},
+		{"uuid.UUID", reflect.TypeOf(uuid.UUID{}), true},
+		{"regular_struct", reflect.TypeOf(struct{ Name string }{}), false},
+		{"string", reflect.TypeOf(""), false},
+		{"int", reflect.TypeOf(int(0)), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isSpecialStructType(tt.t); got != tt.want {
+				t.Errorf("isSpecialStructType() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// Test for ParseTypeErasedPointer function
+func TestParseTypeErasedPointer(t *testing.T) {
+	// Test successful case
+	t.Run("success", func(t *testing.T) {
+		type TestSource struct {
+			Value string
+		}
+
+		type TestDest struct {
+			Result string
+		}
+
+		source := &TestSource{Value: "test"}
+		dest := &TestDest{}
+
+		parseFunc := func(src *TestSource, dst any) error {
+			d := dst.(*TestDest)
+			d.Result = "parsed:" + src.Value
+			return nil
+		}
+
+		err := ParseTypeErasedPointer(source, dest, parseFunc)
+		if err != nil {
+			t.Errorf("ParseTypeErasedPointer() error = %v", err)
+		}
+
+		if dest.Result != "parsed:test" {
+			t.Errorf("ParseTypeErasedPointer() result = %v, want %v", dest.Result, "parsed:test")
+		}
+	})
+
+	// Test wrong source type
+	t.Run("wrong_source_type", func(t *testing.T) {
+		type TestSource struct {
+			Value string
+		}
+
+		type TestDest struct {
+			Result string
+		}
+
+		source := "wrong type"
+		dest := &TestDest{}
+
+		parseFunc := func(src *TestSource, dst any) error {
+			return nil
+		}
+
+		err := ParseTypeErasedPointer(source, dest, parseFunc)
+		if err == nil {
+			t.Error("ParseTypeErasedPointer() should error with wrong source type")
+		}
+	})
+
+	// Test wrong destination type
+	t.Run("wrong_dest_type", func(t *testing.T) {
+		type TestSource struct {
+			Value string
+		}
+
+		source := &TestSource{Value: "test"}
+		dest := "wrong type"
+
+		parseFunc := func(src *TestSource, dst any) error {
+			return nil
+		}
+
+		err := ParseTypeErasedPointer(source, dest, parseFunc)
+		if err == nil {
+			t.Error("ParseTypeErasedPointer() should error with wrong destination type")
+		}
+	})
+
+	// Test parse function error
+	t.Run("parse_error", func(t *testing.T) {
+		type TestSource struct {
+			Value string
+		}
+
+		type TestDest struct {
+			Result string
+		}
+
+		source := &TestSource{Value: "test"}
+		dest := &TestDest{}
+
+		parseFunc := func(src *TestSource, dst any) error {
+			return errors.New("parse error")
+		}
+
+		err := ParseTypeErasedPointer(source, dest, parseFunc)
+		if err == nil {
+			t.Error("ParseTypeErasedPointer() should propagate parse function error")
+		}
+		if err.Error() != "parse error" {
+			t.Errorf("ParseTypeErasedPointer() error = %v, want %v", err, "parse error")
+		}
+	})
+}
+
+// Test for ParseTypeErasedSlice function
+func TestParseTypeErasedSlice(t *testing.T) {
+	// Test successful case
+	t.Run("success", func(t *testing.T) {
+		type TestSource struct {
+			Value string
+		}
+
+		type TestDest struct {
+			Results []string
+		}
+
+		source := []TestSource{{Value: "test1"}, {Value: "test2"}}
+		dest := &TestDest{}
+
+		parseFunc := func(src []TestSource, dst any) error {
+			d := dst.(*TestDest)
+			for _, s := range src {
+				d.Results = append(d.Results, "parsed:"+s.Value)
+			}
+			return nil
+		}
+
+		err := ParseTypeErasedSlice(source, dest, parseFunc)
+		if err != nil {
+			t.Errorf("ParseTypeErasedSlice() error = %v", err)
+		}
+
+		expected := []string{"parsed:test1", "parsed:test2"}
+		if !reflect.DeepEqual(dest.Results, expected) {
+			t.Errorf("ParseTypeErasedSlice() result = %v, want %v", dest.Results, expected)
+		}
+	})
+
+	// Test wrong source type
+	t.Run("wrong_source_type", func(t *testing.T) {
+		type TestSource struct {
+			Value string
+		}
+
+		type TestDest struct {
+			Results []string
+		}
+
+		source := "wrong type"
+		dest := &TestDest{}
+
+		parseFunc := func(src []TestSource, dst any) error {
+			return nil
+		}
+
+		err := ParseTypeErasedSlice(source, dest, parseFunc)
+		if err == nil {
+			t.Error("ParseTypeErasedSlice() should error with wrong source type")
+		}
+	})
+
+	// Test wrong destination type
+	t.Run("wrong_dest_type", func(t *testing.T) {
+		type TestSource struct {
+			Value string
+		}
+
+		source := []TestSource{{Value: "test"}}
+		dest := "wrong type"
+
+		parseFunc := func(src []TestSource, dst any) error {
+			return nil
+		}
+
+		err := ParseTypeErasedSlice(source, dest, parseFunc)
+		if err == nil {
+			t.Error("ParseTypeErasedSlice() should error with wrong destination type")
+		}
+	})
+
+	// Test parse function error
+	t.Run("parse_error", func(t *testing.T) {
+		type TestSource struct {
+			Value string
+		}
+
+		type TestDest struct {
+			Results []string
+		}
+
+		source := []TestSource{{Value: "test"}}
+		dest := &TestDest{}
+
+		parseFunc := func(src []TestSource, dst any) error {
+			return errors.New("parse error")
+		}
+
+		err := ParseTypeErasedSlice(source, dest, parseFunc)
+		if err == nil {
+			t.Error("ParseTypeErasedSlice() should propagate parse function error")
+		}
+		if err.Error() != "parse error" {
+			t.Errorf("ParseTypeErasedSlice() error = %v, want %v", err, "parse error")
+		}
+	})
+}
+
+// Helper function to get pointer to value
+func ptr[T any](v T) *T {
+	return &v
+}

--- a/json_parser_test.go
+++ b/json_parser_test.go
@@ -1,0 +1,140 @@
+package pave
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Test JSON parsers
+func TestJSONByteSliceSourceParser(t *testing.T) {
+	parser := NewJsonByteSliceSourceParser()
+
+	t.Run("NewJsonByteSliceSourceParser", func(t *testing.T) {
+		assert.NotNil(t, parser)
+	})
+
+	t.Run("SourceType", func(t *testing.T) {
+		sourceType := parser.SourceType()
+		assert.Equal(t, JSONByteSliceType, sourceType)
+	})
+
+	t.Run("Name", func(t *testing.T) {
+		name := parser.Name()
+		assert.Equal(t, JSONByteSliceParserName, name)
+	})
+
+	t.Run("Parse_Success", func(t *testing.T) {
+		jsonData := []byte(`{"name": "John", "age": 30}`)
+
+		var result struct {
+			Name string `json:"name"`
+			Age  int    `json:"age"`
+		}
+
+		err := parser.Parse(jsonData, &result)
+		require.NoError(t, err)
+		assert.Equal(t, "John", result.Name)
+		assert.Equal(t, 30, result.Age)
+	})
+
+	t.Run("Parse_NestedJson", func(t *testing.T) {
+		jsonData := []byte(`{"person": {"name": "John", "age": 30}}`)
+		var result struct {
+			Person struct {
+				Name string `json:"name"`
+				Age  int    `json:"age"`
+			} `json:"person"`
+		}
+		err := parser.Parse(jsonData, &result)
+		require.NoError(t, err)
+		assert.Equal(t, "John", result.Person.Name)
+		assert.Equal(t, 30, result.Person.Age)
+	})
+
+	t.Run("Parse_InvalidJSON", func(t *testing.T) {
+		jsonData := []byte(`{"name": "John", "age":}`) // Invalid JSON
+
+		var result struct {
+			Name string `json:"name"`
+			Age  int    `json:"age"`
+		}
+
+		err := parser.Parse(jsonData, &result)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "error unmarshaling JSON data")
+	})
+}
+
+func TestJSONStringSourceParser(t *testing.T) {
+	parser := NewJSONStringSourceParser()
+
+	t.Run("NewJSONStringSourceParser", func(t *testing.T) {
+		assert.NotNil(t, parser)
+	})
+
+	t.Run("SourceType", func(t *testing.T) {
+		sourceType := parser.SourceType()
+		assert.Equal(t, StringType, sourceType)
+	})
+
+	t.Run("Name", func(t *testing.T) {
+		name := parser.Name()
+		assert.Equal(t, JSONStringParserName, name)
+	})
+
+	t.Run("Parse_Success", func(t *testing.T) {
+		jsonString := `{"name": "John", "age": 30}`
+
+		var result struct {
+			Name string `json:"name"`
+			Age  int    `json:"age"`
+		}
+
+		err := parser.Parse(&jsonString, &result)
+		require.NoError(t, err)
+		assert.Equal(t, "John", result.Name)
+		assert.Equal(t, 30, result.Age)
+	})
+
+	t.Run("Parse_NestedJson", func(t *testing.T) {
+		jsonString := `{"person": {"name": "John", "age": 30}}`
+		var result struct {
+			Person struct {
+				Name string `json:"name"`
+				Age  int    `json:"age"`
+			} `json:"person"`
+		}
+		err := parser.Parse(&jsonString, &result)
+		require.NoError(t, err)
+		assert.Equal(t, "John", result.Person.Name)
+		assert.Equal(t, 30, result.Person.Age)
+	})
+
+	t.Run("Parse_InvalidJSON", func(t *testing.T) {
+		jsonString := `{"name": "John", "age":}` // Invalid JSON
+
+		var result struct {
+			Name string `json:"name"`
+			Age  int    `json:"age"`
+		}
+
+		err := parser.Parse(&jsonString, &result)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "error unmarshaling JSON data")
+	})
+
+	t.Run("Parse_EmptyString", func(t *testing.T) {
+		jsonString := ""
+
+		var result struct {
+			Name string `json:"name"`
+			Age  int    `json:"age"`
+		}
+
+		err := parser.Parse(&jsonString, &result)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "error unmarshaling JSON data")
+	})
+}

--- a/parse_chain_test.go
+++ b/parse_chain_test.go
@@ -1,0 +1,326 @@
+package pave
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Test ParseChain functionality
+func TestParseChain_SingleStepExecute(t *testing.T) {
+	t.Run("NilHead", func(t *testing.T) {
+		chain := &ParseChain[string]{
+			StructType: reflect.TypeOf(struct{}{}),
+			Head:       nil,
+			Handler: func(source *string, binding Binding) BindingResult {
+				return BindingResultValue("test")
+			},
+		}
+
+		source := "test"
+		dest := &struct{}{}
+
+		err := chain.Execute(&source, dest)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "parse chain is empty")
+	})
+
+	t.Run("SuccessfulExecution", func(t *testing.T) {
+		type TestStruct struct {
+			Field1 string
+		}
+
+		// Create a simple parse step
+		step := &ParseStep[string]{
+			Next: nil,
+			Bindings: []Binding{
+				{
+					Name:       "test",
+					Identifier: "field1",
+					Modifiers:  BindingModifiers{Required: true},
+				},
+			},
+			FieldName:  "Field1",
+			FieldIndex: 0,
+			IsStruct:   false,
+		}
+
+		chain := &ParseChain[string]{
+			StructType: reflect.TypeOf(TestStruct{}),
+			Head:       step,
+			Handler: func(source *string, binding Binding) BindingResult {
+				return BindingResultValue("test_value")
+			},
+		}
+
+		source := "test"
+		dest := &TestStruct{}
+
+		err := chain.Execute(&source, dest)
+		require.NoError(t, err)
+		assert.Equal(t, "test_value", dest.Field1)
+	})
+
+	t.Run("FailedBinding", func(t *testing.T) {
+		type TestStruct struct {
+			Field1 string
+		}
+
+		// Create a simple parse step
+		step := &ParseStep[string]{
+			Next: nil,
+			Bindings: []Binding{
+				{
+					Name:       "test",
+					Identifier: "field1",
+					Modifiers:  BindingModifiers{Required: true},
+				},
+			},
+			FieldName:  "Field1",
+			FieldIndex: 0,
+			IsStruct:   false,
+		}
+
+		chain := &ParseChain[string]{
+			StructType: reflect.TypeOf(TestStruct{}),
+			Head:       step,
+			Handler: func(source *string, binding Binding) BindingResult {
+				return BindingResultNotFound()
+			},
+		}
+
+		source := "test"
+		dest := &TestStruct{}
+
+		err := chain.Execute(&source, dest)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to parse field")
+	})
+}
+
+func TestParseChain_doStepRecursive(t *testing.T) {
+	// This test is merged with the main execution test above
+	// since doStepRecursive is tested through the Execute method
+}
+
+func TestPCManager(t *testing.T) {
+	handler := func(source *string, binding Binding) BindingResult {
+		return BindingResultValue("test")
+	}
+
+	t.Run("NewPCManager", func(t *testing.T) {
+		opts := PCManagerOpts{
+			tagOpts: ParseTagOpts{
+				BindingOpts: BindingOpts{
+					AllowedBindingNames: []string{"json"},
+				},
+			},
+		}
+
+		pcm := NewPCManager(handler, opts)
+		assert.NotNil(t, pcm)
+	})
+
+	t.Run("GetParseChain", func(t *testing.T) {
+		type TestStruct struct {
+			Field1 string `json:"field1"`
+		}
+
+		opts := PCManagerOpts{
+			tagOpts: ParseTagOpts{
+				BindingOpts: BindingOpts{
+					AllowedBindingNames: []string{"json"},
+				},
+			},
+		}
+
+		pcm := NewPCManager(handler, opts)
+
+		chain, err := pcm.GetParseChain(reflect.TypeOf(TestStruct{}))
+		require.NoError(t, err)
+		assert.NotNil(t, chain)
+		assert.Equal(t, reflect.TypeOf(TestStruct{}), chain.StructType)
+	})
+
+	t.Run("GetParseChain_Cached", func(t *testing.T) {
+		type TestStruct struct {
+			Field1 string `json:"field1"`
+		}
+
+		opts := PCManagerOpts{
+			tagOpts: ParseTagOpts{
+				BindingOpts: BindingOpts{
+					AllowedBindingNames: []string{"json"},
+				},
+			},
+		}
+
+		pcm := NewPCManager(handler, opts)
+
+		// First call should create and cache
+		chain1, err := pcm.GetParseChain(reflect.TypeOf(TestStruct{}))
+		require.NoError(t, err)
+
+		// Second call should return cached version
+		chain2, err := pcm.GetParseChain(reflect.TypeOf(TestStruct{}))
+		require.NoError(t, err)
+
+		// Should be the same instance
+		assert.Equal(t, chain1, chain2)
+	})
+
+	t.Run("NewParseChain", func(t *testing.T) {
+		type TestStruct struct {
+			Field1 string `json:"field1"`
+		}
+
+		opts := PCManagerOpts{
+			tagOpts: ParseTagOpts{
+				BindingOpts: BindingOpts{
+					AllowedBindingNames: []string{"json"},
+				},
+			},
+		}
+
+		pcm := NewPCManager(handler, opts)
+
+		chain, err := pcm.NewParseChain(reflect.TypeOf(TestStruct{}))
+		require.NoError(t, err)
+		assert.NotNil(t, chain)
+		assert.NotNil(t, chain.Head)
+		assert.Equal(t, "Field1", chain.Head.FieldName)
+	})
+
+	t.Run("NewParseStep", func(t *testing.T) {
+		type TestStruct struct {
+			Field1 string `json:"field1"`
+		}
+
+		opts := PCManagerOpts{
+			tagOpts: ParseTagOpts{
+				BindingOpts: BindingOpts{
+					AllowedBindingNames: []string{"json"},
+				},
+			},
+		}
+
+		pcm := NewPCManager(handler, opts)
+
+		field := reflect.TypeOf(TestStruct{}).Field(0)
+		step, err := pcm.NewParseStep(field, 0)
+		require.NoError(t, err)
+		assert.NotNil(t, step)
+		assert.Equal(t, "Field1", step.FieldName)
+		assert.Equal(t, 0, step.FieldIndex)
+	})
+}
+
+func TestParseChain_doStepRegular(t *testing.T) {
+	t.Run("SuccessfulBinding", func(t *testing.T) {
+		type TestStruct struct {
+			Field1 string
+		}
+
+		step := &ParseStep[string]{
+			Bindings: []Binding{
+				{
+					Name:       "test",
+					Identifier: "field1",
+					Modifiers:  BindingModifiers{Required: true},
+				},
+			},
+			FieldName:  "Field1",
+			FieldIndex: 0,
+			IsStruct:   false,
+		}
+
+		chain := &ParseChain[string]{
+			StructType: reflect.TypeOf(TestStruct{}),
+			Handler: func(source *string, binding Binding) BindingResult {
+				return BindingResultValue("test_value")
+			},
+		}
+
+		source := "test"
+		dest := &TestStruct{}
+		destValue := reflect.ValueOf(dest).Elem()
+		field := destValue.Field(0)
+
+		err := chain.doStepRegular(&source, field, step)
+		require.NoError(t, err)
+		assert.Equal(t, "test_value", dest.Field1)
+	})
+
+	t.Run("FailedBinding_WithDefault", func(t *testing.T) {
+		type TestStruct struct {
+			Field1 string
+		}
+
+		step := &ParseStep[string]{
+			Bindings: []Binding{
+				{
+					Name:       "test",
+					Identifier: "field1",
+					Modifiers:  BindingModifiers{Required: false, OmitEmpty: true},
+				},
+			},
+			FieldName:    "Field1",
+			FieldIndex:   0,
+			IsStruct:     false,
+			DefaultValue: "default_value",
+		}
+
+		chain := &ParseChain[string]{
+			StructType: reflect.TypeOf(TestStruct{}),
+			Handler: func(source *string, binding Binding) BindingResult {
+				return BindingResultNotFound()
+			},
+		}
+
+		source := "test"
+		dest := &TestStruct{}
+		destValue := reflect.ValueOf(dest).Elem()
+		field := destValue.Field(0)
+
+		err := chain.doStepRegular(&source, field, step)
+		require.NoError(t, err)
+		assert.Equal(t, "default_value", dest.Field1)
+	})
+
+	t.Run("FailedBinding_NoDefault_Required", func(t *testing.T) {
+		type TestStruct struct {
+			Field1 string
+		}
+
+		step := &ParseStep[string]{
+			Bindings: []Binding{
+				{
+					Name:       "test",
+					Identifier: "field1",
+					Modifiers:  BindingModifiers{Required: true},
+				},
+			},
+			FieldName:  "Field1",
+			FieldIndex: 0,
+			IsStruct:   false,
+		}
+
+		chain := &ParseChain[string]{
+			StructType: reflect.TypeOf(TestStruct{}),
+			Handler: func(source *string, binding Binding) BindingResult {
+				return BindingResultNotFound()
+			},
+		}
+
+		source := "test"
+		dest := &TestStruct{}
+		destValue := reflect.ValueOf(dest).Elem()
+		field := destValue.Field(0)
+
+		err := chain.doStepRegular(&source, field, step)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "required field field1 not found in source test")
+	})
+}

--- a/parser_registry.go
+++ b/parser_registry.go
@@ -183,9 +183,7 @@ func (reg *ParserRegistry) Parse(source any, dest any, validate bool) error {
 //
 // If no parser is found, it returns ErrNoParser.
 func (reg *ParserRegistry) tryGetDefaultParser(source any) (Parser, error) {
-	typ := reflect.TypeOf(source)
-
-	parser, err := reg.getParserByName(typ, "")
+	parser, err := reg.getParserByName(source, "")
 	if err != nil {
 		return nil, err
 	}

--- a/parser_registry_test.go
+++ b/parser_registry_test.go
@@ -1,0 +1,475 @@
+package pave
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Mock parser for testing
+type MockParser struct {
+	name       string
+	sourceType reflect.Type
+	parseFunc  func(source any, dest any) error
+}
+
+func (m *MockParser) Name() string {
+	return m.name
+}
+
+func (m *MockParser) SourceType() reflect.Type {
+	return m.sourceType
+}
+
+func (m *MockParser) Parse(source any, dest any) error {
+	if m.parseFunc != nil {
+		return m.parseFunc(source, dest)
+	}
+	return nil
+}
+
+// Mock validatable struct
+type MockValidatable struct {
+	Value     string
+	ShouldErr bool
+}
+
+func (m *MockValidatable) Validate() error {
+	if m.ShouldErr {
+		return errors.New("validation error")
+	}
+	return nil
+}
+
+func TestParserRegistry(t *testing.T) {
+	t.Run("NewParserRegistry_WithDefaults", func(t *testing.T) {
+		registry, err := NewParserRegistry(ParserRegistryOpts{
+			ExcludeDefaults: false,
+		})
+		require.NoError(t, err)
+		assert.NotNil(t, registry)
+	})
+
+	t.Run("NewParserRegistry_WithoutDefaults", func(t *testing.T) {
+		registry, err := NewParserRegistry(ParserRegistryOpts{
+			ExcludeDefaults: true,
+		})
+		require.NoError(t, err)
+		assert.NotNil(t, registry)
+	})
+
+	t.Run("Register", func(t *testing.T) {
+		registry, err := NewParserRegistry(ParserRegistryOpts{
+			ExcludeDefaults: true,
+		})
+		require.NoError(t, err)
+
+		mockParser := &MockParser{
+			name:       "test_parser",
+			sourceType: reflect.TypeOf(""),
+		}
+
+		err = registry.Register(mockParser)
+		assert.NoError(t, err)
+	})
+
+	t.Run("WithParser", func(t *testing.T) {
+		registry, err := NewParserRegistry(ParserRegistryOpts{
+			ExcludeDefaults: true,
+		})
+		require.NoError(t, err)
+
+		ctx := registry.WithParser("test_parser")
+		assert.NotNil(t, ctx)
+		assert.Equal(t, "test_parser", ctx.parserName)
+		assert.Equal(t, registry, ctx.registry)
+	})
+
+	t.Run("Parse_Success", func(t *testing.T) {
+		registry, err := NewParserRegistry(ParserRegistryOpts{
+			ExcludeDefaults: true,
+		})
+		require.NoError(t, err)
+
+		mockParser := &MockParser{
+			name:       "test_parser",
+			sourceType: reflect.TypeOf(""),
+			parseFunc: func(source any, dest any) error {
+				if destPtr, ok := dest.(*MockValidatable); ok {
+					destPtr.Value = "parsed"
+				}
+				return nil
+			},
+		}
+
+		err = registry.Register(mockParser)
+		require.NoError(t, err)
+
+		source := "test_source"
+		dest := &MockValidatable{}
+
+		err = registry.Parse(source, dest, false)
+		assert.NoError(t, err)
+		assert.Equal(t, "parsed", dest.Value)
+	})
+
+	t.Run("Parse_WithValidation_Success", func(t *testing.T) {
+		registry, err := NewParserRegistry(ParserRegistryOpts{
+			ExcludeDefaults: true,
+		})
+		require.NoError(t, err)
+
+		mockParser := &MockParser{
+			name:       "test_parser",
+			sourceType: reflect.TypeOf(""),
+			parseFunc: func(source any, dest any) error {
+				if destPtr, ok := dest.(*MockValidatable); ok {
+					destPtr.Value = "parsed"
+					destPtr.ShouldErr = false
+				}
+				return nil
+			},
+		}
+
+		err = registry.Register(mockParser)
+		require.NoError(t, err)
+
+		source := "test_source"
+		dest := &MockValidatable{}
+
+		err = registry.Parse(source, dest, true)
+		assert.NoError(t, err)
+		assert.Equal(t, "parsed", dest.Value)
+	})
+
+	t.Run("Parse_WithValidation_ValidationError", func(t *testing.T) {
+		registry, err := NewParserRegistry(ParserRegistryOpts{
+			ExcludeDefaults: true,
+		})
+		require.NoError(t, err)
+
+		mockParser := &MockParser{
+			name:       "test_parser",
+			sourceType: reflect.TypeOf(""),
+			parseFunc: func(source any, dest any) error {
+				if destPtr, ok := dest.(*MockValidatable); ok {
+					destPtr.Value = "parsed"
+					destPtr.ShouldErr = true
+				}
+				return nil
+			},
+		}
+
+		err = registry.Register(mockParser)
+		require.NoError(t, err)
+
+		source := "test_source"
+		dest := &MockValidatable{}
+
+		err = registry.Parse(source, dest, true)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "validation failed")
+	})
+
+	t.Run("Parse_ParseError", func(t *testing.T) {
+		registry, err := NewParserRegistry(ParserRegistryOpts{
+			ExcludeDefaults: true,
+		})
+		require.NoError(t, err)
+
+		mockParser := &MockParser{
+			name:       "test_parser",
+			sourceType: reflect.TypeOf(""),
+			parseFunc: func(source any, dest any) error {
+				return errors.New("parse error")
+			},
+		}
+
+		err = registry.Register(mockParser)
+		require.NoError(t, err)
+
+		source := "test_source"
+		dest := &MockValidatable{}
+
+		err = registry.Parse(source, dest, false)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to parse")
+	})
+
+	t.Run("Parse_NilDest", func(t *testing.T) {
+		registry, err := NewParserRegistry(ParserRegistryOpts{
+			ExcludeDefaults: true,
+		})
+		require.NoError(t, err)
+
+		source := "test_source"
+
+		err = registry.Parse(source, nil, false)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "dest cannot be nil")
+	})
+
+	t.Run("Parse_NonPointerDest", func(t *testing.T) {
+		registry, err := NewParserRegistry(ParserRegistryOpts{
+			ExcludeDefaults: true,
+		})
+		require.NoError(t, err)
+
+		source := "test_source"
+		dest := MockValidatable{}
+
+		err = registry.Parse(source, dest, false)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "dest must be a non-nil pointer to a struct type")
+	})
+
+	t.Run("Parse_NoParserFound", func(t *testing.T) {
+		registry, err := NewParserRegistry(ParserRegistryOpts{
+			ExcludeDefaults: true,
+		})
+		require.NoError(t, err)
+
+		source := "test_source"
+		dest := &MockValidatable{}
+
+		err = registry.Parse(source, dest, false)
+		assert.Error(t, err)
+	})
+
+	t.Run("tryGetDefaultParser", func(t *testing.T) {
+		registry, err := NewParserRegistry(ParserRegistryOpts{
+			ExcludeDefaults: true,
+		})
+		require.NoError(t, err)
+
+		mockParser := &MockParser{
+			name:       "test_parser",
+			sourceType: reflect.TypeOf(""),
+		}
+
+		err = registry.Register(mockParser)
+		require.NoError(t, err)
+
+		source := "test_source"
+		parser, err := registry.tryGetDefaultParser(source)
+		assert.NoError(t, err)
+		assert.Equal(t, mockParser, parser)
+	})
+
+	t.Run("getParserByName", func(t *testing.T) {
+		registry, err := NewParserRegistry(ParserRegistryOpts{
+			ExcludeDefaults: true,
+		})
+		require.NoError(t, err)
+
+		mockParser := &MockParser{
+			name:       "test_parser",
+			sourceType: reflect.TypeOf(""),
+		}
+
+		err = registry.Register(mockParser)
+		require.NoError(t, err)
+
+		source := "test_source"
+		parser, err := registry.getParserByName(source, "test_parser")
+		assert.NoError(t, err)
+		assert.Equal(t, mockParser, parser)
+	})
+
+	t.Run("Invalidate", func(t *testing.T) {
+		registry, err := NewParserRegistry(ParserRegistryOpts{
+			ExcludeDefaults: true,
+		})
+		require.NoError(t, err)
+
+		dest := &MockValidatable{Value: "test"}
+
+		err = registry.Invalidate(dest)
+		assert.NoError(t, err)
+		// Note: Invalidate should zero out the struct fields
+		assert.Equal(t, "", dest.Value)
+	})
+}
+
+func TestParserRegistryContext(t *testing.T) {
+	t.Run("Parse_Success", func(t *testing.T) {
+		registry, err := NewParserRegistry(ParserRegistryOpts{
+			ExcludeDefaults: true,
+		})
+		require.NoError(t, err)
+
+		mockParser := &MockParser{
+			name:       "test_parser",
+			sourceType: reflect.TypeOf(""),
+			parseFunc: func(source any, dest any) error {
+				if destPtr, ok := dest.(*MockValidatable); ok {
+					destPtr.Value = "parsed_context"
+				}
+				return nil
+			},
+		}
+
+		err = registry.Register(mockParser)
+		require.NoError(t, err)
+
+		ctx := registry.WithParser("test_parser")
+		source := "test_source"
+		dest := &MockValidatable{}
+
+		err = ctx.Parse(source, dest, false)
+		assert.NoError(t, err)
+		assert.Equal(t, "parsed_context", dest.Value)
+	})
+
+	t.Run("Parse_WithValidation_Success", func(t *testing.T) {
+		registry, err := NewParserRegistry(ParserRegistryOpts{
+			ExcludeDefaults: true,
+		})
+		require.NoError(t, err)
+
+		mockParser := &MockParser{
+			name:       "test_parser",
+			sourceType: reflect.TypeOf(""),
+			parseFunc: func(source any, dest any) error {
+				if destPtr, ok := dest.(*MockValidatable); ok {
+					destPtr.Value = "parsed_context"
+					destPtr.ShouldErr = false
+				}
+				return nil
+			},
+		}
+
+		err = registry.Register(mockParser)
+		require.NoError(t, err)
+
+		ctx := registry.WithParser("test_parser")
+		source := "test_source"
+		dest := &MockValidatable{}
+
+		err = ctx.Parse(source, dest, true)
+		assert.NoError(t, err)
+		assert.Equal(t, "parsed_context", dest.Value)
+	})
+
+	t.Run("Parse_ValidationError", func(t *testing.T) {
+		registry, err := NewParserRegistry(ParserRegistryOpts{
+			ExcludeDefaults: true,
+		})
+		require.NoError(t, err)
+
+		mockParser := &MockParser{
+			name:       "test_parser",
+			sourceType: reflect.TypeOf(""),
+			parseFunc: func(source any, dest any) error {
+				if destPtr, ok := dest.(*MockValidatable); ok {
+					destPtr.Value = "parsed_context"
+					destPtr.ShouldErr = true
+				}
+				return nil
+			},
+		}
+
+		err = registry.Register(mockParser)
+		require.NoError(t, err)
+
+		ctx := registry.WithParser("test_parser")
+		source := "test_source"
+		dest := &MockValidatable{}
+
+		err = ctx.Parse(source, dest, true)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "validation failed")
+	})
+
+	t.Run("Parse_ParseError", func(t *testing.T) {
+		registry, err := NewParserRegistry(ParserRegistryOpts{
+			ExcludeDefaults: true,
+		})
+		require.NoError(t, err)
+
+		mockParser := &MockParser{
+			name:       "test_parser",
+			sourceType: reflect.TypeOf(""),
+			parseFunc: func(source any, dest any) error {
+				return errors.New("context parse error")
+			},
+		}
+
+		err = registry.Register(mockParser)
+		require.NoError(t, err)
+
+		ctx := registry.WithParser("test_parser")
+		source := "test_source"
+		dest := &MockValidatable{}
+
+		err = ctx.Parse(source, dest, false)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to parse")
+	})
+
+	t.Run("Parse_ParserNotFound", func(t *testing.T) {
+		registry, err := NewParserRegistry(ParserRegistryOpts{
+			ExcludeDefaults: true,
+		})
+		require.NoError(t, err)
+
+		ctx := registry.WithParser("nonexistent_parser")
+		source := "test_source"
+		dest := &MockValidatable{}
+
+		err = ctx.Parse(source, dest, false)
+		assert.Error(t, err)
+	})
+}
+
+// Test package-level functions
+func TestPackageLevelFunctions(t *testing.T) {
+	t.Run("RegisterParser", func(t *testing.T) {
+		mockParser := &MockParser{
+			name:       "package_test_parser",
+			sourceType: reflect.TypeOf(123),
+		}
+
+		err := RegisterParser(mockParser)
+		assert.NoError(t, err)
+	})
+
+	t.Run("WithParser", func(t *testing.T) {
+		ctx := WithParser("test_parser")
+		assert.NotNil(t, ctx)
+	})
+
+	t.Run("Parse", func(t *testing.T) {
+		// This may fail if no parser is registered, but we're testing the function exists
+		source := "test"
+		dest := &MockValidatable{}
+		err := Parse(source, dest, false)
+		// Don't assert success/failure as it depends on registered parsers
+		_ = err
+	})
+
+	t.Run("Invalidate", func(t *testing.T) {
+		dest := &MockValidatable{Value: "test"}
+		err := Invalidate(dest)
+		assert.NoError(t, err)
+	})
+
+	t.Run("GetParser", func(t *testing.T) {
+		source := "test"
+		parser, err := GetParser(source)
+		// Don't assert success/failure as it depends on registered parsers
+		_ = parser
+		_ = err
+	})
+
+	t.Run("GetParserByName", func(t *testing.T) {
+		source := "test"
+		parser, err := GetParserByName(source, "test_parser")
+		// Don't assert success/failure as it depends on registered parsers
+		_ = parser
+		_ = err
+	})
+}

--- a/tag_test.go
+++ b/tag_test.go
@@ -1,0 +1,251 @@
+package pave
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Test tag parsing functionality
+func TestDecodeParseTagV2(t *testing.T) {
+	t.Run("BasicSuccess", func(t *testing.T) {
+		type TestStruct struct {
+			Field1 string `json:"field1" default:"default_value"`
+		}
+
+		field := reflect.TypeOf(TestStruct{}).Field(0)
+		opts := ParseTagOpts{
+			BindingOpts: BindingOpts{
+				AllowedBindingNames: []string{"json"},
+			},
+			AllowedTagOptionals: []string{},
+		}
+
+		tag, err := DecodeParseTagV2(field, opts)
+		require.NoError(t, err)
+		assert.Equal(t, "default_value", tag.defaultTag.Value)
+		assert.False(t, tag.recursiveTag.Enabled)
+	})
+
+	t.Run("RecursiveTag", func(t *testing.T) {
+		type NestedStruct struct {
+			Value string
+		}
+
+		type TestStruct struct {
+			Field1 NestedStruct `json:"field1" recursive:"true"`
+		}
+
+		field := reflect.TypeOf(TestStruct{}).Field(0)
+		opts := ParseTagOpts{
+			BindingOpts: BindingOpts{
+				AllowedBindingNames: []string{"json"},
+			},
+			AllowedTagOptionals: []string{},
+		}
+
+		tag, err := DecodeParseTagV2(field, opts)
+		require.NoError(t, err)
+		assert.True(t, tag.recursiveTag.Enabled)
+	})
+
+	t.Run("NoTags", func(t *testing.T) {
+		type TestStruct struct {
+			Field1 string
+		}
+
+		field := reflect.TypeOf(TestStruct{}).Field(0)
+		opts := ParseTagOpts{
+			BindingOpts: BindingOpts{
+				AllowedBindingNames: []string{"json"},
+			},
+			AllowedTagOptionals: []string{},
+		}
+
+		tag, err := DecodeParseTagV2(field, opts)
+		require.NoError(t, err)
+		assert.Equal(t, "", tag.defaultTag.Value)
+		assert.False(t, tag.recursiveTag.Enabled)
+	})
+}
+
+func TestDecodeBindingTagV2(t *testing.T) {
+	t.Run("BasicBinding", func(t *testing.T) {
+		opts := BindingOpts{
+			AllowedBindingNames: []string{"json"},
+		}
+
+		tag, err := decodeBindingTagV2("json", "field1", opts)
+		require.NoError(t, err)
+		assert.Equal(t, "field1", tag.Identifier)
+		assert.Equal(t, "json", tag.Name)
+		assert.Empty(t, tag.Modifiers)
+	})
+
+	t.Run("BindingWithModifiers", func(t *testing.T) {
+		opts := BindingOpts{
+			AllowedBindingNames: []string{"json"},
+		}
+
+		tag, err := decodeBindingTagV2("json", "field1,omitempty,omitnil", opts)
+		require.NoError(t, err)
+		assert.Equal(t, "field1", tag.Identifier)
+		assert.Equal(t, "json", tag.Name)
+		assert.Contains(t, tag.Modifiers, "omitempty")
+		assert.Contains(t, tag.Modifiers, "omitnil")
+	})
+
+	t.Run("EmptyValue", func(t *testing.T) {
+		opts := BindingOpts{
+			AllowedBindingNames: []string{"json"},
+		}
+
+		_, err := decodeBindingTagV2("json", "", opts)
+		assert.Error(t, err)
+	})
+}
+
+func TestDecodeDefaultTagV2(t *testing.T) {
+	t.Run("WithDefaultTag", func(t *testing.T) {
+		type TestStruct struct {
+			Field1 string `default:"test_default"`
+		}
+
+		field := reflect.TypeOf(TestStruct{}).Field(0)
+		tag, err := decodeDefaultTagV2(field)
+		require.NoError(t, err)
+		assert.Equal(t, "test_default", tag.Value)
+	})
+
+	t.Run("WithoutDefaultTag", func(t *testing.T) {
+		type TestStruct struct {
+			Field1 string `json:"field1"`
+		}
+
+		field := reflect.TypeOf(TestStruct{}).Field(0)
+		tag, err := decodeDefaultTagV2(field)
+		require.NoError(t, err)
+		assert.Equal(t, "", tag.Value)
+	})
+}
+
+func TestDecodeRecursiveTagV2(t *testing.T) {
+	t.Run("StructTypeWithoutRecursiveTag", func(t *testing.T) {
+		type NestedStruct struct {
+			Value string
+		}
+
+		type TestStruct struct {
+			Field1 NestedStruct
+		}
+
+		field := reflect.TypeOf(TestStruct{}).Field(0)
+		tag, err := decodeRecursiveTagV2(field)
+		require.NoError(t, err)
+		// Should default to true for struct types without explicit recursive tag
+		assert.True(t, tag.Enabled)
+	})
+
+	t.Run("NonStructType", func(t *testing.T) {
+		type TestStruct struct {
+			Field1 string
+		}
+
+		field := reflect.TypeOf(TestStruct{}).Field(0)
+		tag, err := decodeRecursiveTagV2(field)
+		require.NoError(t, err)
+		assert.False(t, tag.Enabled)
+	})
+}
+
+func TestMakeBindings(t *testing.T) {
+	t.Run("BasicBinding", func(t *testing.T) {
+		parseTag := ParseTag{
+			bindingTags: []BindingTag{
+				{
+					Name:       "json",
+					Identifier: "field1",
+					Modifiers:  []string{"omitempty"},
+				},
+			},
+		}
+
+		opts := ParseTagOpts{
+			BindingOpts: BindingOpts{
+				CustomBindingModifiers: []string{},
+			},
+		}
+
+		bindings, err := makeBindings(parseTag, opts)
+		require.NoError(t, err)
+		assert.Len(t, bindings, 1)
+		assert.Equal(t, "json", bindings[0].Name)
+		assert.Equal(t, "field1", bindings[0].Identifier)
+		assert.False(t, bindings[0].Modifiers.Required) // omitempty makes it not required
+	})
+
+	t.Run("RequiredBinding", func(t *testing.T) {
+		parseTag := ParseTag{
+			bindingTags: []BindingTag{
+				{
+					Name:       "json",
+					Identifier: "field1",
+					Modifiers:  []string{}, // No modifiers = required
+				},
+			},
+		}
+
+		opts := ParseTagOpts{
+			BindingOpts: BindingOpts{
+				CustomBindingModifiers: []string{},
+			},
+		}
+
+		bindings, err := makeBindings(parseTag, opts)
+		require.NoError(t, err)
+		assert.Len(t, bindings, 1)
+		assert.True(t, bindings[0].Modifiers.Required)
+	})
+}
+
+func TestBindingTag_toBinding(t *testing.T) {
+	t.Run("OmitEmptyModifier", func(t *testing.T) {
+		tag := BindingTag{
+			Name:       "json",
+			Identifier: "field1",
+			Modifiers:  []string{OmitEmptyBindingModifier},
+		}
+
+		binding, err := tag.toBinding([]string{})
+		require.NoError(t, err)
+		assert.Equal(t, "json", binding.Name)
+		assert.Equal(t, "field1", binding.Identifier)
+		assert.False(t, binding.Modifiers.Required)
+	})
+
+	t.Run("OmitNilModifier", func(t *testing.T) {
+		tag := BindingTag{
+			Name:       "json",
+			Identifier: "field1",
+			Modifiers:  []string{OmitNilBindingModifier},
+		}
+
+		binding, err := tag.toBinding([]string{})
+		require.NoError(t, err)
+		assert.False(t, binding.Modifiers.Required)
+	})
+
+	t.Run("NoModifiers", func(t *testing.T) {
+		tag := BindingTag{
+			Name:       "json",
+			Identifier: "field1",
+			Modifiers:  []string{},
+		}
+
+		binding, err := tag.toBinding([]string{})
+		require.NoError(t, err)
+		assert.True(t, binding.Modifiers.Required)
+	})
+}


### PR DESCRIPTION
Comprehensive changes:
```mc
	- BindingCache: 
		- Fixed issue with gc sometimes removing unsafe.pointer references from sync.Map instance. Swapped to *S instead.
		- Fixed issue with Clear() deleting keys mid cache.Range() causing corruption
		- Added binding_cache_test.go
	- Helpers
		- Rewrote/Refactored most of setFieldValue to be more tolerant of all reflect.Kind values
		- Added overflow checks
		- Added encoding.TextUnmarshaller support for fields that implement the interface.
		- Added helpers_test.go
	- HTTPRequestParser
		- Added more tests to cover BindingHandler failure cases
	- ParserRegistry
		- Fixed issue with tryGetDefaultParser passing reflect.Type to getParserByName instead of original source type.
		- Added parser_registry_test.go
	- Binding
		- Added binding_test.go (kinda useless ngl)
	- Json<String|ByteSlice>Parser
		- Added json_parser_test.go
	- ParseChain / ParseChainManager
		- Added parse_chain_test.go
	- Tag
		- Added tag_test.go
```